### PR TITLE
Fix sidebar trailing slash handling

### DIFF
--- a/src/util/sidebar.ts
+++ b/src/util/sidebar.ts
@@ -130,7 +130,7 @@ function setSidebarCurrentEntry(
 			const href = entry.href;
 
 			// Compare with and without trailing slash
-			if (href === pathname || href.slice(0, -1) === href) {
+			if (href === pathname || href.slice(0, -1) === pathname) {
 				entry.isCurrent = true;
 				return true;
 			}


### PR DESCRIPTION
## Summary
- ensure sidebar current item is detected with or without a trailing slash

## Testing
- `npm test` *(fails: 403 Forbidden when fetching vitest)*

------
https://chatgpt.com/codex/tasks/task_e_684c7c1877b083278432f9b0846fc94b